### PR TITLE
url-search-params-polyfillを追加

### DIFF
--- a/app/javascript/app/components/app.jsx
+++ b/app/javascript/app/components/app.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
+import 'url-search-params-polyfill';
 
 import MainContent from '../containers/main-content';
 import EmojiDetailPopup from '../containers/emoji-detail-popup';

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "redux-saga": "^0.16.0",
     "style-loader": "^0.21.0",
     "styled-components": "^3.3.2",
+    "url-search-params-polyfill": "^4.0.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6656,6 +6656,10 @@ url-parse@^1.1.8:
     querystringify "~1.0.0"
     requires-port "~1.0.0"
 
+url-search-params-polyfill@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-4.0.1.tgz#4eda68a5689eda19aff2287e65d98d6fb5f6bc11"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
URLSearchParamsがchromeの昔のバージョンで動かなかったため
close #219